### PR TITLE
Some Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# IDEA Specific
+/.idea
+*.iml
+
+# Eclipse Specific
+.classpath
+.project
+.externalToolBuilders
+
+# Holdovers from the ol' Ant system
+/bin
+/lib
+
+# Prevent Maven Leakage
+/target
+
+# Javadoc
+/doc
+
+# RedHat Dependency Analytics LSP server
+/lsp
+
+# OS specific
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+.factorypath
+.settings
+.vscode

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <description>Removes weapon cooldown entirely.</description>
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <url>https://github.com/engdave</url>

--- a/src/main/java/me/engineerdave/cooldownremover/attackcooldownremover/AttackCooldownRemover.java
+++ b/src/main/java/me/engineerdave/cooldownremover/attackcooldownremover/AttackCooldownRemover.java
@@ -1,6 +1,5 @@
 package me.engineerdave.cooldownremover.attackcooldownremover;
 
-import org.bukkit.Bukkit;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.entity.Player;
@@ -13,8 +12,8 @@ public final class AttackCooldownRemover extends JavaPlugin implements Listener 
 
     @Override
     public void onEnable() {
-        System.out.println("Launching Cooldown Remover...");
-        Bukkit.getServer().getPluginManager().registerEvents(this, this);
+        getLogger().info("Launching Cooldown Remover...");
+        getServer().getPluginManager().registerEvents(this, this);
     }
 
     @EventHandler
@@ -31,6 +30,6 @@ public final class AttackCooldownRemover extends JavaPlugin implements Listener 
 
     @Override
     public void onDisable() {
-        System.out.println("Disabling Cooldown Remover...");
+        getLogger().info("Disabling Cooldown Remover...");
     }
 }

--- a/src/main/java/me/engineerdave/cooldownremover/attackcooldownremover/AttackCooldownRemover.java
+++ b/src/main/java/me/engineerdave/cooldownremover/attackcooldownremover/AttackCooldownRemover.java
@@ -18,14 +18,14 @@ public final class AttackCooldownRemover extends JavaPlugin implements Listener 
 
     @EventHandler
     public void onAttack(EntityDamageByEntityEvent event) {
-        if (!(event.getDamager() instanceof Player)) {
+        if (!(event.getDamager() instanceof Player player)) {
             return;
         }
 
-        Player player = (Player) event.getDamager();
         AttributeInstance attackSpeed = player.getAttribute(Attribute.GENERIC_ATTACK_SPEED);
-        assert attackSpeed != null;
-        attackSpeed.setBaseValue(Double.POSITIVE_INFINITY);
+        if (attackSpeed != null) {
+            attackSpeed.setBaseValue(Double.POSITIVE_INFINITY);
+        }
     }
 
     @Override


### PR DESCRIPTION
- Replaced static access to the server with a class access from the plugin instance
- Replaced the use of `System.out.println` with the plugin logger. This avoids warnings in Paper servers
- According to the plugin description, it only supports Minecraft 1.19.3, where Java 17 is used. So, I upgraded the Java compatible version to Java 17 and use the new pattern matching
- Now it avoids throwing an exception through the "_assert_" in case the `AttributeInstance` is null, now simply use the variable if it is not null